### PR TITLE
Add Next.js starter for split bill app with Supabase

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_SUPABASE_URL=https://your-supabase-url.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.next/
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# split-bill
+# Split Bill
+
+This is a simple example of a split bill tracker built with Next.js and Supabase. It allows you to add bills and see them listed on the page.
+
+## Setup
+
+1. Copy `.env.example` to `.env` and fill in your Supabase project details.
+2. Install dependencies (requires internet access):
+   ```bash
+   npm install
+   ```
+3. Run the development server:
+   ```bash
+   npm run dev
+   ```
+
+Open <http://localhost:3000> in your browser to see the app.
+
+## Supabase Table
+
+Create a table called `bills` with the following columns:
+- `id` (bigint, primary key)
+- `name` (text)
+- `total` (numeric)
+- `participants` (text[])

--- a/components/BillForm.tsx
+++ b/components/BillForm.tsx
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+import { addBill } from '../lib/supabase/bills';
+
+export default function BillForm({ onAdded }: { onAdded: () => void }) {
+  const [name, setName] = useState('');
+  const [total, setTotal] = useState(0);
+  const [participants, setParticipants] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      await addBill({
+        name,
+        total,
+        participants: participants.split(',').map((p) => p.trim()),
+      });
+      setName('');
+      setTotal(0);
+      setParticipants('');
+      onAdded();
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input
+        type="text"
+        placeholder="Bill name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+      />
+      <input
+        type="number"
+        placeholder="Total amount"
+        value={total}
+        onChange={(e) => setTotal(Number(e.target.value))}
+      />
+      <input
+        type="text"
+        placeholder="Participants comma separated"
+        value={participants}
+        onChange={(e) => setParticipants(e.target.value)}
+      />
+      <button type="submit" disabled={loading}>
+        {loading ? 'Saving...' : 'Add Bill'}
+      </button>
+    </form>
+  );
+}

--- a/lib/supabase/bills.ts
+++ b/lib/supabase/bills.ts
@@ -1,0 +1,27 @@
+import { supabase } from './client';
+
+export interface Bill {
+  id?: number;
+  name: string;
+  total: number;
+  participants: string[];
+}
+
+export async function getBills() {
+  const { data, error } = await supabase
+    .from('bills')
+    .select('*')
+    .order('id', { ascending: false });
+  if (error) throw error;
+  return data as Bill[];
+}
+
+export async function addBill(bill: Bill) {
+  const { data, error } = await supabase
+    .from('bills')
+    .insert([bill])
+    .select()
+    .single();
+  if (error) throw error;
+  return data as Bill;
+}

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string;
+
+export const supabase = createClient(supabaseUrl, supabaseKey);

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "split-bill",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@supabase/supabase-js": "2.39.5"
+  },
+  "devDependencies": {
+    "typescript": "5.3.3",
+    "eslint": "8.56.0",
+    "eslint-config-next": "14.2.3"
+  }
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,6 @@
+import type { AppProps } from 'next/app';
+import '../public/global.css';
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+import BillForm from '../components/BillForm';
+import { getBills, Bill } from '../lib/supabase/bills';
+
+export default function Home() {
+  const [bills, setBills] = useState<Bill[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  async function loadBills() {
+    setLoading(true);
+    try {
+      const data = await getBills();
+      setBills(data);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    loadBills();
+  }, []);
+
+  return (
+    <div>
+      <h1>Split Bill</h1>
+      <BillForm onAdded={loadBills} />
+      {loading ? (
+        <p>Loading...</p>
+      ) : (
+        <ul>
+          {bills.map((bill) => (
+            <li key={bill.id}>
+              {bill.name}: ${bill.total} split between {bill.participants.join(', ')}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/public/global.css
+++ b/public/global.css
@@ -1,0 +1,9 @@
+body {
+  font-family: sans-serif;
+  padding: 2rem;
+}
+
+form > * {
+  display: block;
+  margin-bottom: 0.5rem;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- set up package.json with Next.js and Supabase dependencies
- initialize TypeScript config and base Next.js files
- add Supabase client and bill helpers
- create a bill entry form and index page
- document setup instructions in README

## Testing
- `npm run lint` *(fails: `next` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cd8028c74832db9beda6473a4f492